### PR TITLE
fix flaky tests/test_pdl.py::pdl_test_helper

### DIFF
--- a/tests/test_pdl.py
+++ b/tests/test_pdl.py
@@ -126,7 +126,9 @@ def pdl_test_helper(url, archive=True):
 
     if archive:
         assert not os.path.exists(file_location)
-
+    else:
+        os.unlink(file_location)
+        
 
 def stop_server():
     """ Stop HTTP server """


### PR DESCRIPTION
This PR aims to fix the flaky test `tests/test_pdl.py::pdl_test_helper`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the parameters `file_location` didn't get cleared. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 test/base/validate/test_unit.py`
Notice that the PR is modifying the testsuite to make it more robust without changing the source code.